### PR TITLE
Adds `:name` option to allow multiple schema registries

### DIFF
--- a/lib/confluent_schema.ex
+++ b/lib/confluent_schema.ex
@@ -2,13 +2,14 @@ defmodule ConfluentSchema do
   @moduledoc """
   Provides cache and validation for confluent schemas.
   """
-  alias ConfluentSchema.Cache
+  alias ConfluentSchema.{Cache, Server}
   alias ExJsonSchema.Validator
 
   @type errors :: [{message :: binary, path :: binary}]
 
   @doc """
   Validates the payload against the schema for the given subject.
+  If you need to validate against multiple schema registries, use the `cache_name` option.
 
   ## Examples
 
@@ -21,12 +22,51 @@ defmodule ConfluentSchema do
       iex> ConfluentSchema.validate(123, "subject")
       {:error, [{"Type mismatch. Expected String but got Integer.", "#"}]}
   """
-  @spec validate(map, binary) ::
+  @spec validate(map, binary, atom()) ::
           {:ok, map} | {:error, :not_found} | {:error, errors} | no_return
-  def validate(payload, subject) do
-    with {:ok, schema} <- Cache.get(subject),
+  def validate(payload, subject, cache_name \\ ConfluentSchema.Cache) do
+    with {:ok, schema} <- Cache.get(subject, cache_name),
          :ok <- Validator.validate(schema, payload) do
       {:ok, payload}
     end
   end
+
+  @doc """
+  Start a server to periodically fetch and cache Confluent schemas.
+
+  You can get credentials from [Confluent Cloud](https://confluent.cloud): Login > Home > Environments.
+  Or you can also spin off your own Confluent Schema Registry server.
+
+  ## Options
+
+    * `period` - Period in milliseconds to update schemas (optional integer, default 5 minutes)
+    * `debug` - Enable debug logs (optional boolean, default false)
+    * `name` - Name of the GenServer and ETS cache, (optional atom)
+               Useful when multiple schema registries are needed.
+               (default `ConfluentSchema.Server` for the GenServer and `ConfluentSchema.Cache` for the ETS table)
+
+  ## [ConfluentSchemaRegistry](https://hexdocs.pm/confluent_schema_registry/) options
+
+    * `base_url` - URL of schema registry (optional, default "http://localhost:8081")
+    * `username` - username or api key (optional)
+    * `password` - password or api secret (optional)
+    * `adapter` - Tesla Adapter (optional, default `Tesla.Adapter.Hackney`)
+    * `middleware` - List of [Tesla middlewares](https://hexdocs.pm/tesla/readme.html#middleware) (optional)
+
+  ## Example
+
+      opts = [
+        period: :timer.minutes(5),
+        debug: false,
+        base_url: "http://localhost:8081",
+        username: "key",
+        password: "api secret",
+        adapter: {Tesla.Adapter.Hackney, hackney_opts},
+        middleware: []
+      ]
+
+      children = [{ConfluentSchema, opts}]
+      Supervisor.start_link(children, strategy: :one_for_one)
+  """
+  def start_link(opts), do: Server.start_link(opts)
 end

--- a/lib/confluent_schema/cache.ex
+++ b/lib/confluent_schema/cache.ex
@@ -1,6 +1,5 @@
 defmodule ConfluentSchema.Cache do
   @moduledoc "Cache Confluent schemas on ETS table."
-  @ets_table :confluent_schema_cache
 
   @doc """
   Starts cache for Confluent schemas.
@@ -10,14 +9,15 @@ defmodule ConfluentSchema.Cache do
   ## Example
 
       iex> Cache.start()
-      :#{@ets_table}
+      :"#{__MODULE__}"
 
       iex> Cache.start()
       iex> assert_raise ArgumentError, fn -> Cache.start() end
   """
   @spec start() :: true | no_return
-  def start() do
-    :ets.new(@ets_table, [:named_table, read_concurrency: true])
+
+  def start(table_name \\ __MODULE__) do
+    :ets.new(table_name, [:named_table, read_concurrency: true])
   end
 
   @doc """
@@ -34,8 +34,8 @@ defmodule ConfluentSchema.Cache do
       
   """
   @spec set(binary, map) :: true | no_return
-  def set(subject, schema) do
-    :ets.insert(@ets_table, {subject, schema})
+  def set(subject, schema, table_name \\ __MODULE__) do
+    :ets.insert(table_name, {subject, schema})
   end
 
   @doc """
@@ -54,8 +54,8 @@ defmodule ConfluentSchema.Cache do
       {:error, :not_found}
   """
   @spec get(binary) :: {:ok, map} | {:error, :not_found} | no_return
-  def get(subject) do
-    case :ets.lookup(@ets_table, subject) do
+  def get(subject, table_name \\ __MODULE__) do
+    case :ets.lookup(table_name, subject) do
       [{^subject, schema}] -> {:ok, schema}
       [] -> {:error, :not_found}
     end

--- a/lib/confluent_schema/server.ex
+++ b/lib/confluent_schema/server.ex
@@ -38,16 +38,23 @@ defmodule ConfluentSchema.Server do
   """
   @spec start_link(Keyword.t()) :: Supervisor.on_start()
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
   end
 
   @doc false
   @spec init(Keyword.t()) :: {:ok, map, {:continue, atom()}}
   def init(opts) do
-    Cache.start()
-    default = [debug: false, period: :timer.minutes(5), registry: Registry.create(opts)]
-    state = Keyword.merge(default, opts)
-    {:ok, Map.new(state), {:continue, :cache}}
+    default = [
+      debug: false,
+      name: ConfluentSchema.Cache,
+      period: :timer.minutes(5),
+      registry: Registry.create(opts)
+    ]
+
+    state = default |> Keyword.merge(opts) |> Map.new()
+    Cache.start(state.name)
+    {:ok, state, {:continue, :cache}}
   end
 
   @doc false
@@ -57,18 +64,18 @@ defmodule ConfluentSchema.Server do
   @doc false
   @spec handle_info(atom(), map()) :: {:noreply, map()}
   def handle_info(:cache, state) do
-    cache(state.registry, state.debug)
+    cache(state.registry, state.debug, state.name)
     Process.send_after(self(), :cache, state.period)
     {:noreply, state}
   end
 
-  defp cache(registry, debug) do
+  defp cache(registry, debug, name) do
     case Registry.get_subject_schemas(registry) do
       {:ok, subject_schemas} ->
         Enum.each(subject_schemas, fn {subject, schema} ->
           # For performance, we cache the resolved schema.
           # https://hexdocs.pm/ex_json_schema/readme.html#resolving-a-schema
-          Cache.set(subject, ExJsonSchema.Schema.resolve(schema))
+          Cache.set(subject, ExJsonSchema.Schema.resolve(schema), name)
         end)
 
       {:error, step, code, reason} ->

--- a/test/confluent_schema/server_test.exs
+++ b/test/confluent_schema/server_test.exs
@@ -21,6 +21,12 @@ defmodule ConfluentSchema.ServerTest do
     assert wait_until(fn -> Cache.get("bar") end)
   end
 
+  test "allow multiple GenServers" do
+    assert {:ok, pid1} = Server.start_link(name: :foo)
+    assert {:ok, pid2} = Server.start_link(name: :bar)
+    assert pid1 != pid2
+  end
+
   defp wait_until(fun) do
     case fun.() do
       {:ok, result} -> result


### PR DESCRIPTION
Closes #3 

This PR was originally here: https://github.com/loopsocial/confluent_schema/pull/6
But it was merged to the wrong branch. I'm reopening to merge it to main.